### PR TITLE
fix: builder connection

### DIFF
--- a/src/components/builder/Editor.tsx
+++ b/src/components/builder/Editor.tsx
@@ -187,12 +187,12 @@ export async function createEditor(
 
       if (context.data.target.length > 3) {
         const node = editor.getNode(context.data.target);
-        target = node.temp_id;
+        target = node.temp_id ? node.temp_id : node.id;
       }
 
       if (context.data.source.length > 3) {
         const node = editor.getNode(context.data.source);
-        source = node.temp_id;
+        source = node.temp_id ? node.temp_id : node.id;
       }
 
       // if self connection ?


### PR DESCRIPTION
Editor new connection cannot be created for old / fetched nodes, because temp_id only exists in temporarily created nodes.