### PR TITLE
fix: display clear buttons if input values already exist

### DIFF
--- a/src/components/prompt/GeneratorInput.tsx
+++ b/src/components/prompt/GeneratorInput.tsx
@@ -69,74 +69,78 @@ export const GeneratorInput: React.FC<GeneratorInputProps> = ({
 
   return inputs.length > 0 ? (
     <Box>
-      {inputs.map((input, index) => (
-        <React.Fragment key={index} >
-          <Divider sx={{ borderColor: 'surface.3' }} />
-          <Stack direction={'row'} alignItems={'center'} gap={1}
-            sx={{ p: '16px 8px 16px 16px' }}
-          >
-            <InputLabel
-              sx={{
-                fontSize: 13,
-                fontWeight: 500,
-                color: errors[input.name] ? 'error.main' : 'tertiary',
-                height: '27px',
-              }}
+      {inputs.map((input, index) => {
+        const inputValue = resInputs.find((prompt: any) => prompt.id === promptId)?.inputs[input.name]
+        || '';
+
+        return (
+          <React.Fragment key={index} >
+            <Divider sx={{ borderColor: 'surface.3' }} />
+            <Stack direction={'row'} alignItems={'center'} gap={1}
+              sx={{ p: '16px 8px 16px 16px' }}
             >
-              {input.fullName}:
-            </InputLabel>
-            <TextField
-              sx={{
-                flex: 1,
-                height: '27px',
-                '.MuiInputBase-input': {
-                  p: 0,
-                  color: 'onSurface',
+              <InputLabel
+                sx={{
                   fontSize: 13,
                   fontWeight: 500,
-                  '&::placeholder': {
-                    color: 'grey.600',
-                    opacity: 1
+                  color: errors[input.name] ? 'error.main' : 'tertiary',
+                  height: '27px',
+                }}
+              >
+                {input.fullName}:
+              </InputLabel>
+              <TextField
+                sx={{
+                  flex: 1,
+                  height: '27px',
+                  '.MuiInputBase-input': {
+                    p: 0,
+                    color: 'onSurface',
+                    fontSize: 13,
+                    fontWeight: 500,
+                    '&::placeholder': {
+                      color: 'grey.600',
+                      opacity: 1
+                    },
+                    '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {
+                      WebkitAppearance: 'none',
+                      margin: 0,
+                    },
+                    '&[type=number]': {
+                      MozAppearance: 'textfield',
+                    },
                   },
-                  '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {
-                    WebkitAppearance: 'none',
-                    margin: 0,
+                  '.MuiOutlinedInput-notchedOutline': {
+                    border: 0,
                   },
-                  '&[type=number]': {
-                    MozAppearance: 'textfield',
+                  '.MuiInputBase-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                    border: 0,
                   },
-                },
-                '.MuiOutlinedInput-notchedOutline': {
-                  border: 0,
-                },
-                '.MuiInputBase-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                  border: 0,
-                },
-              }}
-              placeholder={input.type === 'number' ? 'Write a number here..' : 'Type here...'}
-              type={input.type}
-              value={resInputs.find((prompt: any) => prompt.id === promptId)?.inputs[input.name]
-                || ''}
-              onChange={e => handleChange(e.target.value, input.name, input.type)}
-            />
-            <IconButton 
-               sx={{ 
-                  color: 'grey.600', 
-                  border: "none", 
-                  p: "4px", 
-                  ":hover": { 
-                       color: "tertiary" 
-                  }, 
-                  display: displayClearButton ? 'inline-flex' : 'none', 
-                  height: '27px' 
-               }}
-              onClick={() => handleChange('', input.name, input.type)}
-            >
-              <Backspace />
-            </IconButton>
-          </Stack>
-        </React.Fragment>
-      ))}
+                }}
+                placeholder={input.type === 'number' ? 'Write a number here..' : 'Type here...'}
+                type={input.type}
+                value={inputValue}
+                onChange={e => handleChange(e.target.value, input.name, input.type)}
+              />
+              <IconButton 
+                sx={{ 
+                    color: 'grey.600', 
+                    border: "none", 
+                    p: "4px", 
+                    ":hover": { 
+                        color: "tertiary" 
+                    }, 
+                    display: displayClearButton || inputValue ? 'inline-flex' : 'none', 
+                    height: '27px' 
+                }}
+                onClick={() => handleChange('', input.name, input.type)}
+              >
+                <Backspace />
+              </IconButton>
+            </Stack>
+          </React.Fragment>
+        )
+      })}
     </Box>
     ) : (
       null


### PR DESCRIPTION
Quick fix for clear buttons in templates when the input fields already have text