### PR TITLE
fix: avoid breaking changes of last execute api for now

### DIFF
--- a/src/core/api/templates.ts
+++ b/src/core/api/templates.ts
@@ -26,7 +26,7 @@ export const templatesApi = baseApi.injectEndpoints({
           method: "get",
         }),
       }),
-      getLastTemplates: build.query<Templates, void>({
+      getLastTemplates: build.query<Templates[], void>({
         query: () => ({
           url: "/api/meta/templates/last_executed/",
           method: "get",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -37,7 +37,7 @@ const HomePage: NextPage<HomePageProps> = ({
   const currentUser = useSelector((state: RootState) => state.user.currentUser);
   const [getCurrentUser] =
     userApi.endpoints.getCurrentUser.useLazyQuery();
-  const { data: lastTemplate, isLoading: isLastTemplateLoading } =
+  const { data: lastTemplates, isLoading: isLastTemplatesLoading } =
     useGetLastTemplatesQuery(undefined, { skip: !isValidUser });
   const { data: suggestedTemplates, isLoading: isSuggestedTemplateLoading } =
     useGetTemplatesSuggestedQuery(undefined, { skip: !isValidUser });
@@ -128,18 +128,28 @@ const HomePage: NextPage<HomePageProps> = ({
                     Welcome, {currentUser?.username}
                   </Typography>
                 </Grid>
-                {lastTemplate && Object.keys(lastTemplate).length > 0 && (
-                  <TemplatesSection
-                    isLoading={isLastTemplateLoading}
-                    templates={[lastTemplate]}
-                    title="Your Latest Template:"
-                  />
-                )}
+                {/* back compatibility solution for now */}
+                {lastTemplates && Array.isArray(lastTemplates) && lastTemplates.length
+                  ? <TemplatesSection
+                      isLoading={isLastTemplatesLoading}
+                      templates={lastTemplates}
+                      title="Your Latest Templates:"
+                    /> 
+                  : null
+                }
+                {lastTemplates && !Array.isArray(lastTemplates) && Object.values(lastTemplates).length
+                  ? <TemplatesSection
+                      isLoading={isLastTemplatesLoading}
+                      templates={[lastTemplates]}
+                      title="Your Latest Template:"
+                    /> 
+                  : null
+                }
 
                 <TemplatesSection
                   isLoading={isSuggestedTemplateLoading}
                   templates={suggestedTemplates}
-                  title="You may like this templates:"
+                  title="You may like these templates:"
                 />
                 <CategoriesSection
                   categories={categories}


### PR DESCRIPTION
related #198 

This is a back-compatibility solution until we migrate into production the new api, then we can remove the old implementation of single template execution display