### PR TITLE
fix: add tag filter and other improvements

### DIFF
--- a/src/components/SparksLayoutDesktop.tsx
+++ b/src/components/SparksLayoutDesktop.tsx
@@ -149,9 +149,7 @@ export const SparksLayoutDesktop: FC<SparksLayoutDesktopProps> = ({ execution, t
         display={"flex"}
         gap={1}
         alignItems={"center"}
-      >
-        
-      </Grid>
+      ></Grid>
 
       <Grid
         item

--- a/src/components/SparksLayoutMobile.tsx
+++ b/src/components/SparksLayoutMobile.tsx
@@ -107,15 +107,7 @@ export const SparksLayoutMobile: FC<SparksLayoutMobileProps> = ({ execution, tem
             zIndex: 3,
           }}
         >
-          {execution.is_favorite ? (
-            <SavedSpark
-              size="24"
-            />
-          ) : (
-            <DraftSpark
-              size="24"
-            />
-          )}
+          {execution.is_favorite ? <SavedSpark size="24" /> : <DraftSpark size="24" />}
         </Box>
       </Grid>
       <Grid

--- a/src/components/common/cards/CardTemplate.tsx
+++ b/src/components/common/cards/CardTemplate.tsx
@@ -1,29 +1,19 @@
 import React from "react";
-import {
-  Avatar,
-  Box,
-  Button,
-  Card,
-  CardMedia,
-  Chip,
-  Grid,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { Avatar, Box, Card, CardMedia, Chip, Grid, Stack, Typography } from "@mui/material";
 import { TemplateExecutionsDisplay, Templates } from "@/core/api/dto/templates";
 import ArrowBackIosRoundedIcon from "@mui/icons-material/ArrowBackIosRounded";
 import { useRouter } from "next/router";
+import { useDispatch } from "react-redux";
+import { setSelectedTag } from "@/core/store/filtersSlice";
 
 type CardTemplateProps = {
   template: Templates | TemplateExecutionsDisplay;
   noRedirect?: boolean;
 };
 
-const CardTemplate: React.FC<CardTemplateProps> = ({
-  template,
-  noRedirect = false,
-}) => {
+const CardTemplate: React.FC<CardTemplateProps> = ({ template, noRedirect = false }) => {
   const router = useRouter();
+  const dispatch = useDispatch();
 
   return (
     <Box
@@ -59,7 +49,11 @@ const CardTemplate: React.FC<CardTemplateProps> = ({
             gap={{ xs: "16px", md: 0 }}
             alignItems={"center"}
           >
-            <Grid display={"flex"} alignItems={"center"} gap={"16px"}>
+            <Grid
+              display={"flex"}
+              alignItems={"center"}
+              gap={"16px"}
+            >
               <Grid>
                 <CardMedia
                   sx={{
@@ -74,8 +68,16 @@ const CardTemplate: React.FC<CardTemplateProps> = ({
                   alt={template.title}
                 />
               </Grid>
-              <Grid gap={0.5} sx={{}} display={"flex"} flexDirection={"column"}>
-                <Typography fontSize={14} fontWeight={500}>
+              <Grid
+                gap={0.5}
+                sx={{}}
+                display={"flex"}
+                flexDirection={"column"}
+              >
+                <Typography
+                  fontSize={14}
+                  fontWeight={500}
+                >
                   {template.title}
                 </Typography>
                 <Typography
@@ -108,7 +110,7 @@ const CardTemplate: React.FC<CardTemplateProps> = ({
             display={"flex"}
             alignItems={{ xs: "end", md: "center" }}
             width={{ xs: "100%", md: "auto" }}
-            marginTop={{ xs: "10px", md: "0px"}}
+            marginTop={{ xs: "10px", md: "0px" }}
             justifyContent={"space-between"}
             gap={3}
           >
@@ -118,17 +120,24 @@ const CardTemplate: React.FC<CardTemplateProps> = ({
                 gap: "4px",
               }}
             >
-              {template.tags.slice(0, 3).map((el) => (
+              {template.tags.slice(0, 3).map(tag => (
                 <Chip
-                  key={el.id}
+                  key={tag.id}
                   clickable
                   size="small"
-                  label={el.name}
+                  label={tag.name}
                   sx={{
                     fontSize: { xs: 11, md: 13 },
                     fontWeight: 400,
                     bgcolor: "surface.5",
                     color: "onSurface",
+                  }}
+                  onClick={e => {
+                    e.stopPropagation();
+
+                    dispatch(setSelectedTag(tag));
+
+                    router.push("/explore");
                   }}
                 />
               ))}

--- a/src/components/explorer/ExploreFilterSideBar.tsx
+++ b/src/components/explorer/ExploreFilterSideBar.tsx
@@ -5,21 +5,15 @@ import {
   Button,
   Chip,
   Grid,
-  IconButton,
   List,
   ListItem,
   ListItemButton,
   ListSubheader,
   Typography,
 } from "@mui/material";
-
 import { Engine, Tag } from "@/core/api/dto/templates";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  deleteSelectedTag,
-  setSelectedEngine,
-  setSelectedTag,
-} from "@/core/store/filtersSlice";
+import { deleteSelectedTag, setSelectedEngine, setSelectedTag } from "@/core/store/filtersSlice";
 import { RootState } from "@/core/store";
 
 interface ExploreFilterSideBarProps {
@@ -28,11 +22,7 @@ interface ExploreFilterSideBarProps {
   tags: Tag[] | undefined;
 }
 
-export const ExploreFilterSideBar: React.FC<ExploreFilterSideBarProps> = ({
-  engines,
-  tags,
-  sidebarOpen,
-}) => {
+export const ExploreFilterSideBar: React.FC<ExploreFilterSideBarProps> = ({ engines, tags, sidebarOpen }) => {
   const [itemsToShow, setItemsToShow] = useState<number>(3);
 
   const filters = useSelector((state: RootState) => state.filters);
@@ -61,13 +51,7 @@ export const ExploreFilterSideBar: React.FC<ExploreFilterSideBarProps> = ({
   };
   return (
     <Box sx={{ opacity: sidebarOpen ? 1 : 0 }}>
-      <List
-        subheader={
-          <ListSubheader sx={{ fontSize: "12px", ml: "17px" }}>
-            ENGINES
-          </ListSubheader>
-        }
-      >
+      <List subheader={<ListSubheader sx={{ fontSize: "12px", ml: "17px" }}>ENGINES</ListSubheader>}>
         <Grid
           className="sidebar-list"
           sx={{
@@ -76,8 +60,11 @@ export const ExploreFilterSideBar: React.FC<ExploreFilterSideBarProps> = ({
             overflowX: "none",
           }}
         >
-          {engines?.slice(0, itemsToShow).map((engine) => (
-            <ListItem disablePadding key={engine.name}>
+          {engines?.slice(0, itemsToShow).map(engine => (
+            <ListItem
+              disablePadding
+              key={engine.name}
+            >
               <ListItemButton
                 sx={{ borderRadius: "8px", minHeight: 48, mx: 1, px: 3.0 }}
                 onClick={() => handleEngineSelect(engine)}
@@ -94,7 +81,11 @@ export const ExploreFilterSideBar: React.FC<ExploreFilterSideBarProps> = ({
                     mr: "18px",
                   }}
                 />
-                <Typography fontSize={14} fontWeight={500} color={"onSurface"}>
+                <Typography
+                  fontSize={14}
+                  fontWeight={500}
+                  color={"onSurface"}
+                >
                   {engine.name}
                 </Typography>
               </ListItemButton>
@@ -113,13 +104,7 @@ export const ExploreFilterSideBar: React.FC<ExploreFilterSideBarProps> = ({
           {itemsToShow === 3 ? "See all" : "Show less"}
         </Button>
       </List>
-      <List
-        subheader={
-          <ListSubheader sx={{ fontSize: "12px", ml: "17px" }}>
-            POPULAR TAGS
-          </ListSubheader>
-        }
-      >
+      <List subheader={<ListSubheader sx={{ fontSize: "12px", ml: "17px" }}>POPULAR TAGS</ListSubheader>}>
         <Grid
           display={"flex"}
           flexDirection={"column"}
@@ -127,7 +112,7 @@ export const ExploreFilterSideBar: React.FC<ExploreFilterSideBarProps> = ({
           gap={"8px"}
           ml={"29px"}
         >
-          {tags?.map((tag) => (
+          {tags?.map(tag => (
             <Chip
               sx={{
                 bgcolor: storedTags.includes(tag) ? "#9DB2BF" : "surface.3",

--- a/src/components/prompt/Details.tsx
+++ b/src/components/prompt/Details.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from "react";
-import { Box, Button, Chip, Divider, Stack, Typography, alpha, useTheme } from "@mui/material";
+import { Box, Button, Chip, Stack, Typography, alpha, useTheme } from "@mui/material";
 import { Templates } from "@/core/api/dto/templates";
 import { savePathURL } from "@/common/utils";
-import useToken from "@/hooks/useToken";
 import { Subtitle } from "@/components/blocks";
 import moment from "moment";
 import { useRouter } from "next/router";
-import { useSelector } from "react-redux";
-import FavoriteButton from "@/components/common/buttons/FavoriteButton";
+import { useSelector, useDispatch } from "react-redux";
 import { useAddToCollectionMutation, useRemoveFromCollectionMutation } from "@/core/api/collections";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import FavoriteMobileButton from "@/components/common/buttons/FavoriteMobileButton";
 import { RootState } from "@/core/store";
+import { setSelectedTag } from "@/core/store/filtersSlice";
+import { isValidUserFn } from "@/core/store/userSlice";
 
 interface DetailsProps {
   templateData: Templates;
@@ -29,15 +29,15 @@ export const Details: React.FC<DetailsProps> = ({
   mobile,
 }) => {
   const [isFetching, setIsFetching] = useState(false);
-  const token = useToken();
   const currentUser = useSelector((state: RootState) => state.user.currentUser);
   const router = useRouter();
   const [addToCollection] = useAddToCollectionMutation();
   const [removeFromCollection] = useRemoveFromCollectionMutation();
   const { palette } = useTheme();
-
+  const dispatch = useDispatch();
+  const isValidUser = useSelector(isValidUserFn);
   const favorTemplate = async () => {
-    if (!token) {
+    if (!isValidUser) {
       savePathURL(window.location.pathname);
       return router.push("/signin");
     }
@@ -132,17 +132,11 @@ export const Details: React.FC<DetailsProps> = ({
             templateData.tags.map(tag => (
               <Chip
                 key={tag.id}
-                onClick={() =>
-                  router.push({
-                    pathname: `/`,
-                    query: {
-                      tag: JSON.stringify({
-                        id: tag.id,
-                        name: tag.name,
-                      }),
-                    },
-                  })
-                }
+                onClick={() => {
+                  dispatch(setSelectedTag(tag));
+
+                  router.push("/explore");
+                }}
                 variant={"filled"}
                 label={tag.name}
                 sx={{

--- a/src/core/api/dto/templates.ts
+++ b/src/core/api/dto/templates.ts
@@ -12,7 +12,7 @@ export interface FilterParams {
 
 export interface SelectedFilters {
   engine: Engine | null;
-  tag: (Tag | null)[];
+  tag: Tag[];
   title: string | null;
   category: Category | null;
   subCategory: Category | null;

--- a/src/core/store/filtersSlice.ts
+++ b/src/core/store/filtersSlice.ts
@@ -16,8 +16,12 @@ const filterSlice = createSlice({
     setSelectedEngine: (state, action: PayloadAction<Engine | null>) => {
       state.engine = action.payload;
     },
-    setSelectedTag: (state, action: PayloadAction<Tag | null>) => {
-      state.tag.push(action.payload); // This should work fine now
+    setSelectedTag: (state, action: PayloadAction<Tag>) => {
+      if (state.tag?.find(_tag => _tag.id === action.payload?.id)) {
+        return;
+      }
+
+      state.tag.push(action.payload);
     },
     setSelectedCategory: (state, action: PayloadAction<Category | null>) => {
       state.category = action.payload;


### PR DESCRIPTION
Related to #220 

There are other improvements I added on top of the main issue of this PR:
- Fix displaying templates by tag on template page
- Fix displaying templates by tag on home page
- Fix duplicate added tags
- Add link to filter by tags per template line/row

<img width="500" alt="Screenshot 2023-08-22 at 11 27 24" src="https://github.com/ysfbsf/promptify-next/assets/4919883/d540344d-87ea-4824-b2bc-b5766ac95d0a">
