### PR TITLE
fix: avoid getting previous execution title on empty templates

### DIFF
--- a/src/components/prompt/Display.tsx
+++ b/src/components/prompt/Display.tsx
@@ -16,7 +16,7 @@ interface Props {
   executions: TemplatesExecutions[];
   isFetching?: boolean;
   selectedExecution: TemplatesExecutions | null;
-  setSelectedExecution: (execution: TemplatesExecutions) => void;
+  setSelectedExecution: (execution: TemplatesExecutions | null) => void;
   generatedExecution: PromptLiveResponse | null;
 }
 
@@ -68,6 +68,7 @@ export const Display: React.FC<Props> = ({
 
   const sortedExecutions = useMemo(() => {
     if (!executions?.length) {
+      setSelectedExecution(null);
       return [];
     }
 


### PR DESCRIPTION
Related to #331 