### PR TITLE
builder highlight textfiled: no spaces inside input name

### DIFF
--- a/src/components/builder/HighlightWithinTextarea.tsx
+++ b/src/components/builder/HighlightWithinTextarea.tsx
@@ -136,6 +136,7 @@ export const HighlightTextarea = ({
           placeholder="..."
           stripPastedStyles
           onChange={(newValue, selection) => {
+            newValue = newValue.replace(/\{\{([^{}]*?)\}\}/g, (match, group) => `{{${group.replace(/\s+/g, "")}}}`);
             onChange(newValue, selection);
             showSuggestions(newValue);
           }}


### PR DESCRIPTION
#457 
No spaces allowed inside an input var declaration `{{nospaces}}`