### PR TITLE
fix DomPurify: handle urls

### DIFF
--- a/src/common/helpers/htmlHelper.ts
+++ b/src/common/helpers/htmlHelper.ts
@@ -19,6 +19,7 @@ DOMPurify.addHook("afterSanitizeAttributes", function (node) {
   if ("href" in node) {
     node.setAttribute("target", "_blank");
     node.setAttribute("rel", "noopener noreferrer");
+    node.setAttribute("class", "link");
   }
 });
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -18,6 +18,11 @@ body {
   background-color: #fff;
 }
 
+.link {
+  text-decoration:none;
+  color:#725472;
+}
+
 .github-button {
   border: none;
   background: transparent;


### PR DESCRIPTION
DomPurify removes `a` tags. Urls should be kept with `target={"_blank"} rel={"noopener noreferrer}` 