### PR TITLE
When one connection provider user logout, disconnect btn hover, …

### DIFF
--- a/src/components/common/forms/StackedInput.tsx
+++ b/src/components/common/forms/StackedInput.tsx
@@ -75,6 +75,7 @@ export default function StackedInput({
         gap={3}
         sx={{
           p: rows ? "16px" : "8px 16px",
+          width: rows ? "95%" : "100%",
           ...(!rows && {
             borderBottom: "1px solid",
             borderColor: isFocused ? "primary.main" : "transparent",

--- a/src/components/common/forms/TemplateForm.tsx
+++ b/src/components/common/forms/TemplateForm.tsx
@@ -240,6 +240,8 @@ function TemplateForm({ type = "create", templateData, onSaved, onClose, darkMod
             <TextField
               {...params}
               label="Difficulty"
+              error={Boolean(formik.errors.difficulty)}
+              helperText={formik.errors.difficulty ? formik.errors.difficulty : ""}
             />
           )}
           getOptionLabel={option => option.charAt(0).toUpperCase() + option.slice(1).toLowerCase()}
@@ -273,6 +275,7 @@ function TemplateForm({ type = "create", templateData, onSaved, onClose, darkMod
             />
           )}
           getOptionLabel={option => (option === "1" ? "Yes" : "No")}
+          disableClearable
         />
       </Stack>
       <Stack sx={boxStyle}>
@@ -288,6 +291,8 @@ function TemplateForm({ type = "create", templateData, onSaved, onClose, darkMod
             <TextField
               {...params}
               label="Language"
+              error={Boolean(formik.errors.language)}
+              helperText={formik.errors.language ? formik.errors.language : ""}
             />
           )}
           getOptionLabel={getLanguageFromCode}

--- a/src/components/profile2/Connections.tsx
+++ b/src/components/profile2/Connections.tsx
@@ -14,10 +14,12 @@ import Image from "@/components/design-system/Image";
 import { useAppDispatch } from "@/hooks/useStore";
 import { setToast } from "@/core/store/toastSlice";
 import useBrowser from "@/hooks/useBrowser";
+import useLogout from "@/hooks/useLogout";
 
 export const Connections = () => {
   const router = useRouter();
   const dispatch = useAppDispatch();
+  const logout = useLogout();
   const [connections, setConnections] = useState<IConnection[] | []>([]);
   const [authConnection, setAuthConnection] = useState<string[]>([]);
   const [openDisconnect, setOpenDisconnect] = useState<boolean>(false);
@@ -53,13 +55,17 @@ export const Connections = () => {
   };
   const handleDeleteConnection = (connection: IConnection) => {
     useDeferredAction(connection.id)
-      .then(res => {
+      .then(async res => {
         if (!res && connections?.length) {
           const filterConnection = connections.filter(el => el.id !== connection.id);
-          const cnx = filterConnection.map((cn: any) => cn.provider);
-          setAuthConnection(cnx);
-          setConnections(filterConnection);
-          dispatch(setToast({ message: "Connection deleted successfully", severity: "success", duration: 6000 }));
+          if (connections.length === 1) {
+            await logout();
+          } else {
+            const cnx = filterConnection.map((cn: any) => cn.provider);
+            setAuthConnection(cnx);
+            setConnections(filterConnection);
+            dispatch(setToast({ message: "Connection deleted successfully", severity: "success", duration: 6000 }));
+          }
         } else {
           dispatch(setToast({ message: "Connection not deleted", severity: "error", duration: 6000 }));
         }
@@ -169,6 +175,9 @@ export const Connections = () => {
                   fontSize: 14,
                   fontWeight: 500,
                   color: "onSurface",
+                  ":hover": {
+                    background: "#EFEDF1",
+                  },
                 }}
               >
                 Disconnect

--- a/src/hooks/useTemplateForm.ts
+++ b/src/hooks/useTemplateForm.ts
@@ -100,6 +100,8 @@ const useTemplateForm = ({ type, template, uploadedFile, onSaved }: Props) => {
     title: string().min(1).required("Template title field is required"),
     description: string().min(1).required("Description field is required"),
     thumbnail: string().min(1).required("Please upload a thumbnail."),
+    difficulty: string().min(1).required("Difficulty field is required"),
+    language: string().min(1).required("Language field is required"),
   });
 
   const formik = useFormik<IEditTemplate>({


### PR DESCRIPTION
template builder cross icon visibility, validation on difficulty and language.

## Describe your changes
- [X] Adding validation on template builder 
- [X] hiding corss icon on visibility
- [X] disconnect button hover 
- [X] logout user when removing provider in Account connections when only one provider

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I've attached the ticket's number in `Development` section on the right side.

